### PR TITLE
fix: remove replace statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.21
 
 toolchain go1.21.5
 
-replace akeyless.io/akeyless-main-repo => ../akeyless-main-repo
-
 require (
-	akeyless.io/akeyless-main-repo v0.0.0-00010101000000-000000000000
 	github.com/akeylesslabs/akeyless-go-cloud-id v0.3.4
 	github.com/akeylesslabs/akeyless-go/v4 v4.0.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.2.5 h1:UR4rDjcgpgEnqpIEvkiqTYKBCKLNmlge2eVjoZfySzM=
 github.com/googleapis/enterprise-certificate-proxy v0.2.5/go.mod h1:RxW0N9901Cko1VOCW3SXCpWP+mlIEkk2tP7jnHy9a3w=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"github.com/akeylesslabs/akeyless-go/v4"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	encoding_ex "akeyless.io/akeyless-main-repo/go/src/infra/encoding-ex"
 	"github.com/akeylesslabs/akeyless-go-cloud-id/cloudprovider/aws"
 	"github.com/akeylesslabs/akeyless-go-cloud-id/cloudprovider/azure"
 	"github.com/akeylesslabs/akeyless-go-cloud-id/cloudprovider/gcp"
@@ -173,7 +173,7 @@ func readK8SServiceAccountJWT() (string, error) {
 
 	a := strings.TrimSpace(string(contentBytes))
 
-	return encoding_ex.Base64Encode([]byte(a)), nil
+	return base64.StdEncoding.EncodeToString([]byte(a)), nil
 }
 
 func (c *Config) StartAuthentication(ctx context.Context, closed chan bool) error {


### PR DESCRIPTION
Currently, the CSI provider requires a dependency on a non-public source repository. This makes it impossible to build as-is.


Fortunately, it seems the only touch-point is for encoding the Kubernetes Service Account Token into Base64.
An equivalent function exists in the Go Standard Library, so the dependency can be removed, as it is unneeded. 

External Secrets Operator, a related project, is already using this:
https://github.com/external-secrets/external-secrets/blob/22c1af40e09d20b1bcedf2be28cb7022ba67a702/pkg/provider/akeyless/akeyless_api.go#L58